### PR TITLE
Implement basic syscall argument recognition

### DIFF
--- a/cmd/strace.go
+++ b/cmd/strace.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strings"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
@@ -76,20 +77,94 @@ func strace(c *cli.Context) error {
 			return nil
 		}
 
-		// Print register value on every second trap so that we print only after the syscall is complete
+		// Print register values on every second trap so that we print only after the syscall is complete
 		if traps > 0 && traps%2 == 0 {
-			origRax, err := readOrigRax(childPid)
+			var regs syscall.PtraceRegs
+			err = syscall.PtraceGetRegs(childPid, &regs)
 			if err != nil {
 				return fmt.Errorf("error while reading Orig_rax for child pid %d: %w ", childPid, err)
 			}
-			log.WithFields(log.Fields{
-				"orig_rax": origRax,
-				"syscall":  syscallNameByRax[origRax],
-			}).Info("Caught syscall")
+
+			// Syscall-related data is stored in a number of registers, namely:
+			// - rax (system call number)
+			// - rdi (first arg)
+			// - rsi (second arg)
+			// - rdx (third arg)
+			// - r10 (fourth arg)
+			// - r8 (fifth arg)
+			// - r9 (sixth arg)
+			// For each syscall, we need to hardcode which arguments are of interest
+			// Hence, for educational purposes, only selected syscalls have been
+			// defined (i.e. are recognized) below. The list can grow over time.
+			syscallName := syscallNameByRax[regs.Orig_rax]
+
+			switch syscallName {
+
+			case "openat":
+				dirfd := regs.Rdi
+				path, err := peekText(childPid, uintptr(regs.Rsi))
+				flags := regs.Rdx
+				if err != nil {
+					return fmt.Errorf("error while reading path text for child pid %d: %w", childPid, err)
+				}
+				fmt.Printf("openat(%d, '%s', %d)\n", dirfd, string(path), flags)
+			case "open":
+				path, err := peekText(childPid, uintptr(regs.Rdi))
+				if err != nil {
+					return fmt.Errorf("error while reading path text for child pid %d: %w", childPid, err)
+				}
+				flags := regs.Rsi
+				fmt.Printf("open('%s', %d)\n", path, flags)
+			case "read":
+				fd := regs.Rdi
+				buf := regs.Rsi
+				count := regs.Rdx
+				fmt.Printf("read(%d, %d, %d)\n", fd, buf, count)
+			case "write":
+				fd := regs.Rdi
+				text, err := peekText(childPid, uintptr(regs.Rsi))
+				if err != nil {
+					return fmt.Errorf("error while reading path text for child pid %d: %w", childPid, err)
+				}
+				nbytes := regs.Rdx
+				fmt.Printf("write(%d, '%s', %d)\n", fd, text, nbytes)
+			case "close":
+				fd := regs.Rdi
+				fmt.Printf("close(%d)\n", fd)
+			default:
+				// Print out syscall(n/a) as indication that we cannot parse paramters
+				fmt.Printf("%s(n/a)\n", syscallName)
+			}
+
 		}
 
 		traps++
 	}
+}
+
+// Reads text from another process' memory
+func peekText(pid int, addr uintptr) (string, error) {
+	var sb strings.Builder
+
+	// We will read text bytes one by one
+	// since we don't know the length
+	buf := make([]byte, 1)
+	offset := uintptr(0)
+	for {
+		_, err := syscall.PtracePeekText(pid, addr+offset, buf)
+		if err != nil {
+			return "", err
+		}
+		if buf[0] == 0 {
+			// Byte zero (\0) denotes end of string
+			break
+		}
+
+		sb.Write(buf)
+		offset += 1
+	}
+
+	return sb.String(), nil
 }
 
 func waitPid(pid int) (syscall.WaitStatus, error) {


### PR DESCRIPTION
Adds basic support for printing out selected syscall arguments. Sample output from `ps aux`:

```
openat(4294967196, '/proc/31345/cmdline', 0)
read(6, 140578859614224, 131072)
read(6, 140578859614291, 131005)
close(6)
stat(n/a)
stat(n/a)
```



 

